### PR TITLE
Complete audiobook tagger metadata features

### DIFF
--- a/src-tauri/src/scanner/types.rs
+++ b/src-tauri/src/scanner/types.rs
@@ -57,6 +57,29 @@ pub struct BookMetadata {
     pub cover_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_mime: Option<String>,
+
+    // NEW FIELDS for complete metadata capture
+    /// Multiple authors support (for "Author1 & Author2" cases)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+    /// Multiple narrators support (ABS supports multiple)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub narrators: Vec<String>,
+    /// ISO language code (e.g., "en", "es", "de")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Whether the audiobook is abridged
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub abridged: Option<bool>,
+    /// Total runtime in minutes
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_minutes: Option<u32>,
+    /// Content is explicit (contains mature content)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explicit: Option<bool>,
+    /// Full publish date in YYYY-MM-DD format
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publish_date: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/EditMetadataModal.jsx
+++ b/src/components/EditMetadataModal.jsx
@@ -150,15 +150,69 @@ export function EditMetadataModal({ isOpen, onClose, onSave, metadata, groupName
               />
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">ISBN</label>
-              <input
-                type="text"
-                value={editedMetadata.isbn || ''}
-                onChange={(e) => updateField('isbn', e.target.value || null)}
-                placeholder="Optional"
-                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">ISBN</label>
+                <input
+                  type="text"
+                  value={editedMetadata.isbn || ''}
+                  onChange={(e) => updateField('isbn', e.target.value || null)}
+                  placeholder="Optional"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">ASIN</label>
+                <input
+                  type="text"
+                  value={editedMetadata.asin || ''}
+                  onChange={(e) => updateField('asin', e.target.value || null)}
+                  placeholder="Optional"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Language</label>
+                <select
+                  value={editedMetadata.language || ''}
+                  onChange={(e) => updateField('language', e.target.value || null)}
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="">Select...</option>
+                  <option value="en">English</option>
+                  <option value="es">Spanish</option>
+                  <option value="fr">French</option>
+                  <option value="de">German</option>
+                  <option value="it">Italian</option>
+                  <option value="pt">Portuguese</option>
+                  <option value="ja">Japanese</option>
+                  <option value="zh">Chinese</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Runtime (min)</label>
+                <input
+                  type="number"
+                  value={editedMetadata.runtime_minutes || ''}
+                  onChange={(e) => updateField('runtime_minutes', e.target.value ? parseInt(e.target.value) : null)}
+                  placeholder="Minutes"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              <div className="flex items-center pt-7">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={editedMetadata.abridged === true}
+                    onChange={(e) => updateField('abridged', e.target.checked ? true : null)}
+                    className="w-4 h-4 text-blue-600 rounded focus:ring-blue-500"
+                  />
+                  <span className="text-sm font-medium text-gray-700">Abridged</span>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/scanner/MetadataPanel.jsx
+++ b/src/components/scanner/MetadataPanel.jsx
@@ -219,11 +219,22 @@ export function MetadataPanel({ group, onEdit }) {
                 </div>
               )}
 
-              {/* Narrator */}
-              {metadata.narrator && (
+              {/* Narrator(s) - Support multiple narrators */}
+              {(metadata.narrators?.length > 0 || metadata.narrator) && (
                 <div className="space-y-3">
-                  <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">Narrated by</div>
-                  <p className="text-lg font-medium text-gray-900">{metadata.narrator}</p>
+                  <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+                    Narrated by
+                    {metadata.narrators?.length > 1 && (
+                      <span className="ml-2 px-1.5 py-0.5 bg-gray-200 text-gray-600 rounded text-[10px]">
+                        {metadata.narrators.length}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-lg font-medium text-gray-900">
+                    {metadata.narrators?.length > 0
+                      ? metadata.narrators.join(', ')
+                      : metadata.narrator}
+                  </p>
                 </div>
               )}
 
@@ -253,10 +264,10 @@ export function MetadataPanel({ group, onEdit }) {
                 </div>
               )}
 
-              {/* Publisher & ISBN */}
-              {(metadata.publisher || metadata.isbn) && (
+              {/* Publisher & Identifiers Section */}
+              {(metadata.publisher || metadata.isbn || metadata.asin || metadata.language || metadata.runtime_minutes) && (
                 <div className="pt-6 border-t border-gray-200">
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-6">
                     {metadata.publisher && (
                       <div className="space-y-1">
                         <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">Publisher</div>
@@ -267,6 +278,34 @@ export function MetadataPanel({ group, onEdit }) {
                       <div className="space-y-1">
                         <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">ISBN</div>
                         <div className="text-gray-900 font-mono text-sm">{metadata.isbn}</div>
+                      </div>
+                    )}
+                    {metadata.asin && (
+                      <div className="space-y-1">
+                        <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">ASIN</div>
+                        <div className="text-gray-900 font-mono text-sm">{metadata.asin}</div>
+                      </div>
+                    )}
+                    {metadata.language && (
+                      <div className="space-y-1">
+                        <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">Language</div>
+                        <div className="text-gray-900 font-medium uppercase">{metadata.language}</div>
+                      </div>
+                    )}
+                    {metadata.runtime_minutes && (
+                      <div className="space-y-1">
+                        <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">Runtime</div>
+                        <div className="text-gray-900 font-medium">
+                          {Math.floor(metadata.runtime_minutes / 60)}h {metadata.runtime_minutes % 60}m
+                        </div>
+                      </div>
+                    )}
+                    {metadata.abridged !== null && metadata.abridged !== undefined && (
+                      <div className="space-y-1">
+                        <div className="text-xs font-bold text-gray-500 uppercase tracking-wider">Format</div>
+                        <div className={`font-medium ${metadata.abridged ? 'text-orange-600' : 'text-green-600'}`}>
+                          {metadata.abridged ? 'Abridged' : 'Unabridged'}
+                        </div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Metadata Improvements
- Add new fields to BookMetadata: language, narrators[], authors[], abridged, runtime_minutes, explicit, publish_date
- Extract ALL narrators from Audible (not just first)
- Extract ALL authors from Audible with proper splitting
- Extract description from Audible JSON-LD schema
- Extract language code from Audible pages
- Extract runtime in minutes from Audible
- Detect abridged/unabridged status
- Support multiple narrators joined by semicolon for ABS compatibility

## Cover Art Embedding
- Add embed_cover_in_file() supporting M4A/M4B, MP3, FLAC, OGG/Opus
- Add save_cover_to_folder() for folder.jpg generation
- Proper PNG/JPEG format detection and handling

## Tag Writing Enhancements
- Write ASIN to custom tags (M4A: ASIN atom, MP3: TXXX:ASIN)
- Write ISBN to custom tags (M4A: ISBN atom, MP3: TXXX:ISBN)
- Write language to tags (M4A: lang atom, MP3: TLAN frame)
- Write publisher to tags (M4A: copyright, MP3: TPUB frame)
- Support multiple narrators in Composer field

## Frontend Updates
- Display all narrators with count badge
- Display ASIN, language, runtime, abridged status
- Add language dropdown and runtime input to edit modal
- Add abridged checkbox to edit modal

Implements critical items from the audiobook tagger roadmap.