### PR TITLE
feat: Phase 4 - Export/Import and template-based renaming

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,4 +33,5 @@ sled = "0.34"
 bincode = "1.3"
 mp4ameta = "0.11"
 uuid = { version = "1.18.1", features = ["v4"] }
+csv = "1.3"
 

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,0 +1,221 @@
+// commands/export.rs
+// Export metadata to CSV/JSON formats
+
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
+
+use crate::scanner::types::BookGroup;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ExportRow {
+    title: String,
+    subtitle: String,
+    author: String,
+    narrator: String,
+    series: String,
+    sequence: String,
+    genres: String,
+    publisher: String,
+    year: String,
+    language: String,
+    description: String,
+    isbn: String,
+    asin: String,
+    runtime_minutes: String,
+    abridged: String,
+    file_count: usize,
+    folder_path: String,
+}
+
+impl From<&BookGroup> for ExportRow {
+    fn from(group: &BookGroup) -> Self {
+        let metadata = &group.metadata;
+
+        // Get folder path from first file
+        let folder_path = group.files.first()
+            .map(|f| {
+                std::path::Path::new(&f.path)
+                    .parent()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+
+        ExportRow {
+            title: metadata.title.clone(),
+            subtitle: metadata.subtitle.clone().unwrap_or_default(),
+            author: metadata.author.clone(),
+            narrator: metadata.narrator.clone().unwrap_or_default(),
+            series: metadata.series.clone().unwrap_or_default(),
+            sequence: metadata.sequence.clone().unwrap_or_default(),
+            genres: metadata.genres.join(", "),
+            publisher: metadata.publisher.clone().unwrap_or_default(),
+            year: metadata.year.clone().unwrap_or_default(),
+            language: metadata.language.clone().unwrap_or_default(),
+            description: metadata.description.clone().unwrap_or_default(),
+            isbn: metadata.isbn.clone().unwrap_or_default(),
+            asin: metadata.asin.clone().unwrap_or_default(),
+            runtime_minutes: metadata.runtime_minutes.map(|m| m.to_string()).unwrap_or_default(),
+            abridged: metadata.abridged.map(|b| if b { "Yes" } else { "No" }.to_string()).unwrap_or_default(),
+            file_count: group.files.len(),
+            folder_path,
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn export_to_csv(
+    groups: Vec<BookGroup>,
+    file_path: String,
+) -> Result<String, String> {
+    let rows: Vec<ExportRow> = groups.iter().map(ExportRow::from).collect();
+
+    let mut wtr = csv::Writer::from_path(&file_path)
+        .map_err(|e| format!("Failed to create CSV file: {}", e))?;
+
+    for row in &rows {
+        wtr.serialize(row)
+            .map_err(|e| format!("Failed to write row: {}", e))?;
+    }
+
+    wtr.flush().map_err(|e| format!("Failed to flush CSV: {}", e))?;
+
+    Ok(format!("Exported {} books to {}", rows.len(), file_path))
+}
+
+#[tauri::command]
+pub async fn export_to_json(
+    groups: Vec<BookGroup>,
+    file_path: String,
+    pretty: bool,
+) -> Result<String, String> {
+    let mut file = File::create(&file_path)
+        .map_err(|e| format!("Failed to create JSON file: {}", e))?;
+
+    let json_data = if pretty {
+        serde_json::to_string_pretty(&groups)
+            .map_err(|e| format!("Failed to serialize JSON: {}", e))?
+    } else {
+        serde_json::to_string(&groups)
+            .map_err(|e| format!("Failed to serialize JSON: {}", e))?
+    };
+
+    file.write_all(json_data.as_bytes())
+        .map_err(|e| format!("Failed to write JSON: {}", e))?;
+
+    Ok(format!("Exported {} books to {}", groups.len(), file_path))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportMetadata {
+    pub title: Option<String>,
+    pub subtitle: Option<String>,
+    pub author: Option<String>,
+    pub narrator: Option<String>,
+    pub series: Option<String>,
+    pub sequence: Option<String>,
+    pub genres: Option<Vec<String>>,
+    pub publisher: Option<String>,
+    pub year: Option<String>,
+    pub language: Option<String>,
+    pub description: Option<String>,
+    pub isbn: Option<String>,
+    pub asin: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportResult {
+    pub matched: usize,
+    pub unmatched: usize,
+    pub updates: Vec<ImportUpdate>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportUpdate {
+    pub group_id: String,
+    pub title: String,
+    pub metadata: ImportMetadata,
+}
+
+#[tauri::command]
+pub async fn import_from_csv(
+    file_path: String,
+    groups: Vec<BookGroup>,
+) -> Result<ImportResult, String> {
+    let mut rdr = csv::Reader::from_path(&file_path)
+        .map_err(|e| format!("Failed to read CSV file: {}", e))?;
+
+    let mut updates = Vec::new();
+    let mut matched = 0;
+    let mut unmatched = 0;
+
+    for result in rdr.deserialize() {
+        let row: ExportRow = result.map_err(|e| format!("Failed to parse row: {}", e))?;
+
+        // Try to match by folder path first, then by title
+        let matching_group = groups.iter().find(|g| {
+            let group_folder = g.files.first()
+                .map(|f| {
+                    std::path::Path::new(&f.path)
+                        .parent()
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default();
+
+            group_folder == row.folder_path ||
+            g.metadata.title.to_lowercase() == row.title.to_lowercase()
+        });
+
+        if let Some(group) = matching_group {
+            let metadata = ImportMetadata {
+                title: Some(row.title.clone()),
+                subtitle: if row.subtitle.is_empty() { None } else { Some(row.subtitle) },
+                author: Some(row.author),
+                narrator: if row.narrator.is_empty() { None } else { Some(row.narrator) },
+                series: if row.series.is_empty() { None } else { Some(row.series) },
+                sequence: if row.sequence.is_empty() { None } else { Some(row.sequence) },
+                genres: if row.genres.is_empty() {
+                    None
+                } else {
+                    Some(row.genres.split(',').map(|s| s.trim().to_string()).collect())
+                },
+                publisher: if row.publisher.is_empty() { None } else { Some(row.publisher) },
+                year: if row.year.is_empty() { None } else { Some(row.year) },
+                language: if row.language.is_empty() { None } else { Some(row.language) },
+                description: if row.description.is_empty() { None } else { Some(row.description) },
+                isbn: if row.isbn.is_empty() { None } else { Some(row.isbn) },
+                asin: if row.asin.is_empty() { None } else { Some(row.asin) },
+            };
+
+            updates.push(ImportUpdate {
+                group_id: group.id.clone(),
+                title: row.title,
+                metadata,
+            });
+            matched += 1;
+        } else {
+            unmatched += 1;
+        }
+    }
+
+    Ok(ImportResult {
+        matched,
+        unmatched,
+        updates,
+    })
+}
+
+#[tauri::command]
+pub async fn import_from_json(
+    file_path: String,
+) -> Result<Vec<BookGroup>, String> {
+    let content = std::fs::read_to_string(&file_path)
+        .map_err(|e| format!("Failed to read JSON file: {}", e))?;
+
+    let groups: Vec<BookGroup> = serde_json::from_str(&content)
+        .map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+    Ok(groups)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod abs;
 pub mod maintenance;
 pub mod audible;
 pub mod covers;
+pub mod export;
 
 // Re-export all commands for easy access
 // pub use config::*;

--- a/src-tauri/src/commands/rename.rs
+++ b/src-tauri/src/commands/rename.rs
@@ -11,28 +11,80 @@ pub struct RenamePreview {
     changed: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RenameTemplate {
+    pub id: String,
+    pub name: String,
+    pub file_template: String,
+    pub folder_template: Option<String>,
+}
+
+/// Get available rename templates
+#[tauri::command]
+pub async fn get_rename_templates() -> Vec<RenameTemplate> {
+    vec![
+        RenameTemplate {
+            id: "default".to_string(),
+            name: "Standard".to_string(),
+            file_template: "{author} - {[series #sequence] }{title}{ (year)}".to_string(),
+            folder_template: None,
+        },
+        RenameTemplate {
+            id: "simple".to_string(),
+            name: "Simple".to_string(),
+            file_template: "{author} - {title}".to_string(),
+            folder_template: None,
+        },
+        RenameTemplate {
+            id: "series-first".to_string(),
+            name: "Series First".to_string(),
+            file_template: "{[series #sequence] }{title} - {author}".to_string(),
+            folder_template: None,
+        },
+        RenameTemplate {
+            id: "audiobookshelf".to_string(),
+            name: "AudiobookShelf".to_string(),
+            file_template: "{author} - {series|title}{ #sequence}".to_string(),
+            folder_template: Some("{author}/{series|title}".to_string()),
+        },
+        RenameTemplate {
+            id: "plex".to_string(),
+            name: "Plex Audiobooks".to_string(),
+            file_template: "{title}{ - Part sequence}".to_string(),
+            folder_template: Some("{author}/{title}{ (year)}".to_string()),
+        },
+    ]
+}
+
 #[tauri::command]
 pub async fn preview_rename(
     file_path: String,
     metadata: scanner::BookMetadata,
+    template: Option<String>,
 ) -> Result<RenamePreview, String> {
     use std::path::Path;
-    
+
     let path = Path::new(&file_path);
     let ext = path.extension()
         .and_then(|e| e.to_str())
         .unwrap_or("m4b");
-    
-    let new_filename = file_rename::generate_filename(&file_rename::BookMetadata {
+
+    let file_metadata = file_rename::BookMetadata {
         title: metadata.title.clone(),
         author: metadata.author.clone(),
         series: metadata.series.clone(),
         sequence: metadata.sequence.clone(),
         year: metadata.year.clone(),
-    }, ext);
-    
+        narrator: metadata.narrator.clone(),
+    };
+
+    let new_filename = match template {
+        Some(t) => file_rename::generate_filename_with_template(&file_metadata, ext, &t),
+        None => file_rename::generate_filename(&file_metadata, ext),
+    };
+
     let new_path = path.with_file_name(&new_filename);
-    
+
     Ok(RenamePreview {
         old_path: file_path.clone(),
         new_path: new_path.to_string_lossy().to_string(),
@@ -43,9 +95,10 @@ pub async fn preview_rename(
 #[tauri::command]
 pub async fn rename_files(
     files: Vec<(String, scanner::BookMetadata)>,
+    template: Option<String>,
 ) -> Result<Vec<RenamePreview>, String> {
     let mut results = Vec::new();
-    
+
     for (file_path, metadata) in files {
         let rename_meta = file_rename::BookMetadata {
             title: metadata.title.clone(),
@@ -53,13 +106,15 @@ pub async fn rename_files(
             series: metadata.series.clone(),
             sequence: metadata.sequence.clone(),
             year: metadata.year.clone(),
+            narrator: metadata.narrator.clone(),
         };
-        
+
         match file_rename::rename_and_reorganize_file(
             &file_path,
             &rename_meta,
             false,
             None,
+            template.as_deref(),
         ).await {
             Ok(result) => {
                 results.push(RenamePreview {
@@ -73,6 +128,6 @@ pub async fn rename_files(
             }
         }
     }
-    
+
     Ok(results)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
             commands::tags::inspect_file_tags,
             commands::rename::preview_rename,
             commands::rename::rename_files,
+            commands::rename::get_rename_templates,
             commands::abs::test_abs_connection,
             commands::abs::push_abs_updates,
             commands::abs::force_abs_rescan,
@@ -52,7 +53,10 @@ fn main() {
             commands::covers::download_cover_from_url,
             commands::covers::set_cover_from_file,
             commands::abs::clear_abs_library_cache,
-
+            commands::export::export_to_csv,
+            commands::export::export_to_json,
+            commands::export::import_from_csv,
+            commands::export::import_from_json,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/ExportImportModal.jsx
+++ b/src/components/ExportImportModal.jsx
@@ -1,0 +1,274 @@
+// src/components/ExportImportModal.jsx
+import { useState } from 'react';
+import { X, Download, Upload, FileJson, FileSpreadsheet, Check, AlertCircle } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { save, open } from '@tauri-apps/plugin-dialog';
+
+export function ExportImportModal({ isOpen, onClose, groups, onImport }) {
+  const [mode, setMode] = useState('export'); // 'export' or 'import'
+  const [format, setFormat] = useState('csv'); // 'csv' or 'json'
+  const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  if (!isOpen) return null;
+
+  const handleExport = async () => {
+    setExporting(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const defaultName = `audiobooks_${new Date().toISOString().split('T')[0]}`;
+      const filePath = await save({
+        defaultPath: `${defaultName}.${format}`,
+        filters: format === 'csv'
+          ? [{ name: 'CSV', extensions: ['csv'] }]
+          : [{ name: 'JSON', extensions: ['json'] }],
+      });
+
+      if (!filePath) {
+        setExporting(false);
+        return;
+      }
+
+      let message;
+      if (format === 'csv') {
+        message = await invoke('export_to_csv', { groups, filePath });
+      } else {
+        message = await invoke('export_to_json', { groups, filePath, pretty: true });
+      }
+
+      setResult({ type: 'success', message });
+    } catch (err) {
+      setError(err.toString());
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleImport = async () => {
+    setImporting(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const filePath = await open({
+        filters: format === 'csv'
+          ? [{ name: 'CSV', extensions: ['csv'] }]
+          : [{ name: 'JSON', extensions: ['json'] }],
+      });
+
+      if (!filePath) {
+        setImporting(false);
+        return;
+      }
+
+      if (format === 'csv') {
+        const importResult = await invoke('import_from_csv', { filePath, groups });
+        setResult({
+          type: 'success',
+          message: `Matched ${importResult.matched} books, ${importResult.unmatched} unmatched`,
+          data: importResult,
+        });
+
+        if (importResult.updates.length > 0 && onImport) {
+          onImport(importResult.updates);
+        }
+      } else {
+        const importedGroups = await invoke('import_from_json', { filePath });
+        setResult({
+          type: 'success',
+          message: `Loaded ${importedGroups.length} books from JSON`,
+          data: { groups: importedGroups },
+        });
+
+        if (onImport) {
+          onImport(importedGroups);
+        }
+      }
+    } catch (err) {
+      setError(err.toString());
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setResult(null);
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl max-w-lg w-full overflow-hidden">
+        {/* Header */}
+        <div className="p-6 border-b border-gray-200 bg-gradient-to-r from-indigo-50 to-purple-50">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Export / Import</h2>
+              <p className="text-sm text-gray-600 mt-1">
+                {groups.length} book{groups.length === 1 ? '' : 's'} in library
+              </p>
+            </div>
+            <button onClick={handleClose} className="p-2 hover:bg-indigo-100 rounded-lg transition-colors">
+              <X className="w-6 h-6 text-gray-600" />
+            </button>
+          </div>
+        </div>
+
+        {/* Mode Tabs */}
+        <div className="flex border-b border-gray-200">
+          <button
+            onClick={() => setMode('export')}
+            className={`flex-1 py-3 px-4 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${
+              mode === 'export'
+                ? 'text-indigo-600 border-b-2 border-indigo-600 bg-indigo-50'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+            }`}
+          >
+            <Download className="w-4 h-4" />
+            Export
+          </button>
+          <button
+            onClick={() => setMode('import')}
+            className={`flex-1 py-3 px-4 text-sm font-medium flex items-center justify-center gap-2 transition-colors ${
+              mode === 'import'
+                ? 'text-indigo-600 border-b-2 border-indigo-600 bg-indigo-50'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+            }`}
+          >
+            <Upload className="w-4 h-4" />
+            Import
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          {/* Format Selection */}
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-700 mb-3">Format</label>
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                onClick={() => setFormat('csv')}
+                className={`p-4 rounded-lg border-2 transition-all flex items-center gap-3 ${
+                  format === 'csv'
+                    ? 'border-indigo-500 bg-indigo-50'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <FileSpreadsheet className={`w-6 h-6 ${format === 'csv' ? 'text-indigo-600' : 'text-gray-400'}`} />
+                <div className="text-left">
+                  <div className={`font-medium ${format === 'csv' ? 'text-indigo-900' : 'text-gray-700'}`}>CSV</div>
+                  <div className="text-xs text-gray-500">Spreadsheet format</div>
+                </div>
+              </button>
+              <button
+                onClick={() => setFormat('json')}
+                className={`p-4 rounded-lg border-2 transition-all flex items-center gap-3 ${
+                  format === 'json'
+                    ? 'border-indigo-500 bg-indigo-50'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <FileJson className={`w-6 h-6 ${format === 'json' ? 'text-indigo-600' : 'text-gray-400'}`} />
+                <div className="text-left">
+                  <div className={`font-medium ${format === 'json' ? 'text-indigo-900' : 'text-gray-700'}`}>JSON</div>
+                  <div className="text-xs text-gray-500">Full data backup</div>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          {/* Mode-specific info */}
+          <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+            {mode === 'export' ? (
+              <div className="text-sm text-gray-600">
+                <p className="font-medium text-gray-900 mb-2">Export will include:</p>
+                <ul className="space-y-1 list-disc list-inside">
+                  <li>All metadata fields (title, author, narrator, etc.)</li>
+                  <li>Series and sequence information</li>
+                  <li>Folder paths for each book</li>
+                  {format === 'json' && <li>Full file details and source tracking</li>}
+                </ul>
+              </div>
+            ) : (
+              <div className="text-sm text-gray-600">
+                <p className="font-medium text-gray-900 mb-2">Import will:</p>
+                <ul className="space-y-1 list-disc list-inside">
+                  <li>Match books by folder path or title</li>
+                  <li>Update metadata for matched books</li>
+                  <li>Report unmatched entries</li>
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* Result/Error Display */}
+          {result && (
+            <div className={`mb-4 p-4 rounded-lg flex items-start gap-3 ${
+              result.type === 'success' ? 'bg-green-50' : 'bg-amber-50'
+            }`}>
+              <Check className={`w-5 h-5 flex-shrink-0 ${
+                result.type === 'success' ? 'text-green-600' : 'text-amber-600'
+              }`} />
+              <div className="text-sm">
+                <p className={`font-medium ${
+                  result.type === 'success' ? 'text-green-800' : 'text-amber-800'
+                }`}>
+                  {result.message}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-4 p-4 bg-red-50 rounded-lg flex items-start gap-3">
+              <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0" />
+              <div className="text-sm text-red-800">{error}</div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-200 flex gap-3 justify-end bg-gray-50">
+          <button
+            onClick={handleClose}
+            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+          >
+            Close
+          </button>
+          {mode === 'export' ? (
+            <button
+              onClick={handleExport}
+              disabled={exporting || groups.length === 0}
+              className={`px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-colors ${
+                exporting || groups.length === 0
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-indigo-600 text-white hover:bg-indigo-700'
+              }`}
+            >
+              <Download className="w-4 h-4" />
+              {exporting ? 'Exporting...' : `Export ${groups.length} Books`}
+            </button>
+          ) : (
+            <button
+              onClick={handleImport}
+              disabled={importing}
+              className={`px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-colors ${
+                importing
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-indigo-600 text-white hover:bg-indigo-700'
+              }`}
+            >
+              <Upload className="w-4 h-4" />
+              {importing ? 'Importing...' : 'Import from File'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RenamePreviewModal.jsx
+++ b/src/components/RenamePreviewModal.jsx
@@ -1,24 +1,61 @@
 import { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ArrowRight, CheckCircle } from 'lucide-react';
+import { ArrowRight, CheckCircle, Settings, FileType, Edit3 } from 'lucide-react';
 
 export function RenamePreviewModal({ selectedFiles, metadata, onConfirm, onCancel }) {
   const [previews, setPreviews] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [templates, setTemplates] = useState([]);
+  const [selectedTemplate, setSelectedTemplate] = useState(null);
+  const [customTemplate, setCustomTemplate] = useState('');
+  const [showCustom, setShowCustom] = useState(false);
+
+  // Load templates on mount
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        const result = await invoke('get_rename_templates');
+        setTemplates(result);
+        if (result.length > 0) {
+          setSelectedTemplate(result[0]);
+        }
+      } catch (error) {
+        console.error('Failed to load templates:', error);
+        // Use default if API fails
+        setSelectedTemplate({
+          id: 'default',
+          name: 'Standard',
+          file_template: '{author} - {[series #sequence] }{title}{ (year)}',
+        });
+      }
+    };
+    loadTemplates();
+  }, []);
 
   useEffect(() => {
-    generatePreviews();
-  }, [selectedFiles, metadata]);
+    if (selectedTemplate || customTemplate) {
+      generatePreviews();
+    }
+  }, [selectedFiles, metadata, selectedTemplate, customTemplate]);
+
+  const getCurrentTemplate = () => {
+    if (showCustom && customTemplate) {
+      return customTemplate;
+    }
+    return selectedTemplate?.file_template || null;
+  };
 
   const generatePreviews = async () => {
     setLoading(true);
     const results = [];
+    const template = getCurrentTemplate();
 
     for (const filePath of selectedFiles) {
       try {
         const preview = await invoke('preview_rename', {
           filePath,
           metadata,
+          template,
         });
         results.push(preview);
       } catch (error) {
@@ -36,14 +73,88 @@ export function RenamePreviewModal({ selectedFiles, metadata, onConfirm, onCance
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-xl shadow-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col">
         <div className="p-6 border-b border-gray-200">
-          <h2 className="text-2xl font-bold text-gray-900">Rename Preview</h2>
-          <p className="text-gray-600 mt-1">Review proposed changes before renaming</p>
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Rename Preview</h2>
+              <p className="text-gray-600 mt-1">Review proposed changes before renaming</p>
+            </div>
+            <FileType className="w-8 h-8 text-gray-400" />
+          </div>
+        </div>
+
+        {/* Template Selection */}
+        <div className="px-6 py-4 border-b border-gray-200 bg-gray-50">
+          <div className="flex items-center gap-4">
+            <label className="text-sm font-medium text-gray-700 flex items-center gap-2">
+              <Settings className="w-4 h-4" />
+              Template:
+            </label>
+
+            {!showCustom ? (
+              <div className="flex items-center gap-2 flex-1">
+                <select
+                  value={selectedTemplate?.id || ''}
+                  onChange={(e) => {
+                    const template = templates.find(t => t.id === e.target.value);
+                    setSelectedTemplate(template);
+                  }}
+                  className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  {templates.map(t => (
+                    <option key={t.id} value={t.id}>{t.name}</option>
+                  ))}
+                </select>
+
+                <button
+                  onClick={() => {
+                    setShowCustom(true);
+                    setCustomTemplate(selectedTemplate?.file_template || '');
+                  }}
+                  className="px-2 py-1.5 text-xs text-blue-600 hover:text-blue-800 hover:bg-blue-50 rounded transition-colors flex items-center gap-1"
+                >
+                  <Edit3 className="w-3 h-3" />
+                  Custom
+                </button>
+
+                <div className="text-xs text-gray-500 ml-2 font-mono truncate flex-1">
+                  {selectedTemplate?.file_template}
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 flex-1">
+                <input
+                  type="text"
+                  value={customTemplate}
+                  onChange={(e) => setCustomTemplate(e.target.value)}
+                  placeholder="{author} - {title}"
+                  className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 font-mono"
+                />
+                <button
+                  onClick={() => setShowCustom(false)}
+                  className="px-2 py-1.5 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Template help */}
+          <div className="mt-2 text-xs text-gray-500">
+            <span className="font-medium">Variables:</span>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{author}'}</code>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{title}'}</code>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{series}'}</code>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{sequence}'}</code>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{year}'}</code>{' '}
+            <code className="bg-gray-200 px-1 rounded">{'{narrator}'}</code>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
           {loading ? (
             <div className="flex items-center justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-600"></div>
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
               <span className="ml-3 text-gray-600">Generating previews...</span>
             </div>
           ) : (
@@ -91,13 +202,17 @@ export function RenamePreviewModal({ selectedFiles, metadata, onConfirm, onCance
               {changedCount > 0 && `${changedCount} file(s) will be renamed`}
             </div>
             <div className="flex gap-3">
-              <button onClick={onCancel} className="btn btn-secondary">
+              <button onClick={onCancel} className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors font-medium">
                 Cancel
               </button>
               <button
                 onClick={onConfirm}
                 disabled={changedCount === 0 || loading}
-                className="btn btn-primary flex items-center gap-2"
+                className={`px-4 py-2 rounded-lg font-medium flex items-center gap-2 transition-colors ${
+                  changedCount === 0 || loading
+                    ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    : 'bg-blue-600 text-white hover:bg-blue-700'
+                }`}
               >
                 <CheckCircle className="w-4 h-4" />
                 Confirm Rename

--- a/src/components/scanner/BookList.jsx
+++ b/src/components/scanner/BookList.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X } from 'lucide-react';
+import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X, Download } from 'lucide-react';
 
 // Virtualized item height (approximate)
 const ITEM_HEIGHT = 140;
@@ -20,7 +20,8 @@ export function BookList({
   onScan,
   scanning,
   onSelectAll,
-  onClearSelection
+  onClearSelection,
+  onExport
 }) {
   const [coverCache, setCoverCache] = useState({});
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 30 });
@@ -284,6 +285,15 @@ export function BookList({
               Filters
               {hasActiveFilters && <span className="w-1.5 h-1.5 bg-blue-600 rounded-full" />}
             </button>
+            {onExport && (
+              <button
+                onClick={onExport}
+                className="px-2 py-1 text-xs bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-md transition-colors flex items-center gap-1"
+              >
+                <Download className="w-3 h-3" />
+                Export
+              </button>
+            )}
             <button
               onClick={onSelectAll}
               className="px-2 py-1 text-xs bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-md transition-colors"


### PR DESCRIPTION
- Add export to CSV/JSON functionality with full metadata export
- Add import from CSV/JSON with automatic book matching
- Add template-based file renaming with preset templates
- Add custom template support with variable placeholders
- Template variables: {author}, {title}, {series}, {sequence}, {year}, {narrator}
- Built-in templates for Standard, Simple, Series-first, AudiobookShelf, and Plex
- Add ExportImportModal component with format selection
- Add template selection UI in RenamePreviewModal
- Add Export button to BookList header