### PR TITLE
Improve rename function robustness for chapters

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -70,6 +70,7 @@ fn main() {
             commands::chapters::create_chapters_from_files,
             commands::chapters::merge_chapters,
             commands::chapters::adjust_chapter_boundary,
+            commands::chapters::restore_original_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
- Enhanced chapter/part detection with more filename patterns:
  - Keywords: chapter, chap, track, section, segment, volume, episode, side
  - Leading numbers (01 -, 02_, etc.)
  - Roman numerals (I, II, III, IV, etc.)
  - Pattern matches like "pt1", "ch.2", "part3"
- Add hide_original option to chapter splitting that adds .bak extension to original file, hiding it from ABS (AudiobookShelf)
- Scanner now skips .bak files during collection
- Add restore_original_file command to undo hiding