### PR TITLE
Fix series folder book combining issue

### DIFF
--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -6,6 +6,36 @@ use once_cell::sync::Lazy;
 
 static CANCEL_FLAG: Lazy<Arc<AtomicBool>> = Lazy::new(|| Arc::new(AtomicBool::new(false)));
 
+/// Import folders without metadata scanning - just collect and group files
+#[tauri::command]
+pub async fn import_folders(paths: Vec<String>) -> Result<scanner::ScanResult, String> {
+    println!("📁 import_folders called with {} paths (no metadata scan)", paths.len());
+
+    CANCEL_FLAG.store(false, Ordering::SeqCst);
+
+    let result = scanner::import_directories(&paths, Some(CANCEL_FLAG.clone()))
+        .await
+        .map_err(|e| {
+            println!("❌ Import error: {}", e);
+            e.to_string()
+        })?;
+
+    println!("📊 Import complete: {} groups, {} files", result.groups.len(), result.total_files);
+
+    // DEBUG: Try to serialize to check for cycles
+    match serde_json::to_string(&result) {
+        Ok(json) => {
+            println!("✅ JSON serialization OK, {} bytes", json.len());
+        }
+        Err(e) => {
+            println!("❌ JSON serialization FAILED: {}", e);
+            return Err(format!("Serialization error: {}", e));
+        }
+    }
+
+    Ok(result)
+}
+
 #[tauri::command]
 pub async fn scan_library(paths: Vec<String>) -> Result<scanner::ScanResult, String> {
     println!("🔍 scan_library called with {} paths", paths.len());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
             commands::config::get_config,
             commands::config::save_config,
             commands::scan::scan_library,
+            commands::scan::import_folders,
             commands::scan::cancel_scan,
             commands::scan::get_scan_progress,
             commands::tags::write_tags,

--- a/src/components/scanner/BookList.jsx
+++ b/src/components/scanner/BookList.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X, Download } from 'lucide-react';
+import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X, Download, FolderPlus } from 'lucide-react';
 
 // Virtualized item height (approximate)
 const ITEM_HEIGHT = 140;
@@ -18,6 +18,7 @@ export function BookList({
   onSelectGroup,
   onSelectFile,
   onScan,
+  onImport,
   scanning,
   onSelectAll,
   onClearSelection,
@@ -214,13 +215,27 @@ export function BookList({
             <Upload className="w-12 h-12 text-blue-400 mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-gray-900 mb-2">No Files Scanned</h3>
             <p className="text-gray-600 mb-6 text-sm">Select a folder to scan for audiobook files and view metadata</p>
-            <button 
-              onClick={onScan} 
-              disabled={scanning}
-              className="w-full px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium disabled:opacity-50"
-            >
-              {scanning ? 'Scanning...' : 'Scan Library'}
-            </button>
+            <div className="flex flex-col gap-2">
+              <button
+                onClick={onScan}
+                disabled={scanning}
+                className="w-full px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium disabled:opacity-50"
+              >
+                {scanning ? 'Scanning...' : 'Scan Library'}
+              </button>
+              {onImport && (
+                <button
+                  onClick={onImport}
+                  disabled={scanning}
+                  className="w-full px-4 py-2.5 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium disabled:opacity-50 text-sm"
+                >
+                  Import Without Scanning
+                </button>
+              )}
+            </div>
+            <p className="text-xs text-gray-500 mt-3">
+              Import adds folders without fetching metadata from online sources
+            </p>
           </div>
         </div>
       </div>
@@ -285,6 +300,17 @@ export function BookList({
               Filters
               {hasActiveFilters && <span className="w-1.5 h-1.5 bg-blue-600 rounded-full" />}
             </button>
+            {onImport && (
+              <button
+                onClick={onImport}
+                disabled={scanning}
+                className="px-2 py-1 text-xs bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-md transition-colors flex items-center gap-1 disabled:opacity-50"
+                title="Import folders without metadata scanning"
+              >
+                <FolderPlus className="w-3 h-3" />
+                Import
+              </button>
+            )}
             {onExport && (
               <button
                 onClick={onExport}

--- a/src/pages/ScannerPage.jsx
+++ b/src/pages/ScannerPage.jsx
@@ -28,6 +28,7 @@ export function ScannerPage({ onActionsReady }) {
     scanProgress,
     calculateETA,
     handleScan,
+    handleImport,
     handleRescan,
     cancelScan
   } = useScan();
@@ -495,6 +496,7 @@ export function ScannerPage({ onActionsReady }) {
           onSelectGroup={handleSelectGroup}
           onSelectFile={handleGroupClick}
           onScan={handleScan}
+          onImport={handleImport}
           scanning={scanning}
           onSelectAll={handleSelectAll}
           onClearSelection={handleClearSelection}


### PR DESCRIPTION
- Fix book combining logic to detect multiple books in the same folder:
  - Extract book titles from filenames by removing chapter/part numbers
  - Group files by detected book title instead of just parent directory
  - Detect multiple .m4b files in the same folder as separate books
  - Only split when meaningful distinct titles are found

- Add "Import Without Scanning" feature:
  - New import_folders Tauri command that collects files without metadata enrichment
  - New handleImport function in useScan hook
  - Import button in empty state and header bar
  - Skips Audible, Google Books, and GPT metadata fetching

These changes address the issue where all Mistborn books in a series folder were being combined into a single 145+ hour book with 313 chapters.