### PR TITLE
Allow pushing non-rescanned files with covers

### DIFF
--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -5,10 +5,14 @@ pub mod processor;
 
 pub use types::*;
 use crate::config::Config;
-use std::sync::atomic::{AtomicBool, Ordering};
+use crate::cache;
+use crate::cover_art;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use futures::stream::{self, StreamExt};
 
 /// Import directories without metadata enrichment - just collect and group files
+/// Also fetches covers for books that have metadata
 pub async fn import_directories(
     paths: &[String],
     cancel_flag: Option<Arc<AtomicBool>>
@@ -40,13 +44,91 @@ pub async fn import_directories(
     }
 
     let total_files: usize = groups.iter().map(|g| g.files.len()).sum();
-    println!("📚 Imported {} books with {} total files (no metadata enrichment)", groups.len(), total_files);
+    println!("📚 Imported {} books with {} total files", groups.len(), total_files);
+
+    // Fetch covers for imported books that have metadata
+    println!("🖼️  Fetching covers for imported books...");
+    let groups = fetch_covers_for_groups(groups, cancel_flag).await;
+
+    let covers_count = groups.iter()
+        .filter(|g| g.metadata.cover_url.is_some())
+        .count();
+    println!("✅ Import complete: {} books, {} covers", groups.len(), covers_count);
 
     Ok(ScanResult {
         total_groups: groups.len(),
         total_files,
         groups,
     })
+}
+
+/// Fetch covers for imported groups that have metadata but no cover cached
+async fn fetch_covers_for_groups(
+    groups: Vec<BookGroup>,
+    cancel_flag: Option<Arc<AtomicBool>>
+) -> Vec<BookGroup> {
+    let total = groups.len();
+    let processed = Arc::new(AtomicUsize::new(0));
+    let covers_found = Arc::new(AtomicUsize::new(0));
+
+    crate::progress::set_total(total);
+    crate::progress::update_progress(0, total, "Fetching covers...");
+
+    let results: Vec<BookGroup> = stream::iter(groups)
+        .map(|mut group| {
+            let cancel_flag = cancel_flag.clone();
+            let processed = processed.clone();
+            let covers_found = covers_found.clone();
+            let total = total;
+
+            async move {
+                // Check cancellation
+                if let Some(ref flag) = cancel_flag {
+                    if flag.load(Ordering::Relaxed) {
+                        return group;
+                    }
+                }
+
+                // Only fetch cover if we have enough metadata and no cached cover
+                let cover_cache_key = format!("cover_{}", group.id);
+                let has_cached_cover: bool = cache::get::<(Vec<u8>, String)>(&cover_cache_key).is_some();
+
+                if !has_cached_cover && !group.metadata.title.is_empty() && !group.metadata.author.is_empty() {
+                    // Fetch cover
+                    let cover_result = cover_art::fetch_and_download_cover(
+                        &group.metadata.title,
+                        &group.metadata.author,
+                        group.metadata.asin.as_deref(),
+                        None,
+                    ).await;
+
+                    if let Ok(cover) = cover_result {
+                        if let Some(ref data) = cover.data {
+                            let mime_type = cover.mime_type.clone().unwrap_or_else(|| "image/jpeg".to_string());
+                            let _ = cache::set(&cover_cache_key, &(data.clone(), mime_type.clone()));
+                            group.metadata.cover_url = cover.url;
+                            group.metadata.cover_mime = Some(mime_type);
+                            covers_found.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+
+                let done = processed.fetch_add(1, Ordering::Relaxed) + 1;
+                let covers = covers_found.load(Ordering::Relaxed);
+
+                if done % 10 == 0 || done == total {
+                    crate::progress::update_progress(done, total,
+                        &format!("{}/{} books, {} covers", done, total, covers));
+                }
+
+                group
+            }
+        })
+        .buffer_unordered(10)  // Fetch 10 covers concurrently
+        .collect()
+        .await;
+
+    results
 }
 
 pub async fn scan_directories(

--- a/src/pages/ScannerPage.jsx
+++ b/src/pages/ScannerPage.jsx
@@ -426,28 +426,25 @@ export function ScannerPage({ onActionsReady }) {
     }
   };
 
-  // ✅ SIMPLIFIED - No popup, just push
+  // ✅ Push all selected files (including non-rescanned/imported ones)
   const handlePushClick = async () => {
-    const successCount = getSuccessCount(fileStatuses);
-    
-    if (successCount === 0) {
-      console.log('No files ready to push');
+    if (selectedFiles.size === 0) {
+      console.log('No files selected');
       return;
     }
 
     try {
-      console.log(`📤 Pushing ${successCount} files to AudiobookShelf...`);
-      const successfulFileIds = Array.from(selectedFiles).filter(id => fileStatuses[id] === 'success');
-      
+      console.log(`📤 Pushing ${selectedFiles.size} files to AudiobookShelf...`);
+
       const result = await pushToAudiobookShelf(
-        new Set(successfulFileIds),
+        selectedFiles,
         (progress) => {
           console.log(`Progress: ${progress.itemsProcessed}/${progress.totalItems} items`);
         }
       );
-      
+
       console.log(`✅ Pushed ${result.updated || 0} items`);
-      
+
       if (result.unmatched?.length > 0) {
         console.log(`⚠️ Unmatched: ${result.unmatched.length} files`);
       }


### PR DESCRIPTION
- Modified handlePushClick to push all selected files, not just those with 'success' write status. This allows pushing imported books that haven't been rescanned but have existing metadata.json files.

- Added cover fetching to import_directories function. When importing folders, covers are now fetched for books that have metadata (title, author) but no cached cover. Covers are fetched concurrently (10 at a time) for better performance.