### PR TITLE
Allow pushing non-rescanned files with covers

### DIFF
--- a/src/components/scanner/BookList.jsx
+++ b/src/components/scanner/BookList.jsx
@@ -9,6 +9,7 @@ const BUFFER_SIZE = 10;
 export function BookList({
   groups,
   selectedFiles,
+  allSelected = false,
   selectedGroup,
   selectedGroupIds,
   expandedGroups,
@@ -440,7 +441,7 @@ export function BookList({
           <div style={{ transform: `translateY(${offsetY}px)` }}>
             {filteredGroups.slice(visibleRange.start, visibleRange.end).map((group, idx) => {
               const actualIndex = visibleRange.start + idx;
-              const isInMultiSelect = selectedGroupIds?.has(group.id);
+              const isInMultiSelect = allSelected || selectedGroupIds?.has(group.id);
               const isSingleSelected = selectedGroup?.id === group.id;
               const isSelected = isInMultiSelect || isSingleSelected;
               const metadata = group.metadata;
@@ -588,7 +589,7 @@ export function BookList({
                           <div className="flex items-center gap-3 pl-7">
                             <input
                               type="checkbox"
-                              checked={selectedFiles.has(file.id)}
+                              checked={allSelected || selectedFiles.has(file.id)}
                               onChange={(e) => {
                                 e.stopPropagation();
                               }}


### PR DESCRIPTION
Instead of building huge Sets with all file IDs when selecting all, use an `allSelected` boolean flag. This eliminates the lag when selecting all books in large libraries.

Changes:
- Add allSelected flag to useFileSelection hook
- Update ScannerPage, BookList, and ActionBar to use the flag
- getSelectedFileIds() only materializes the Set when needed (e.g., when actually performing operations like write, push, etc.)
- Selection checks use the flag for O(1) performance instead of iterating through Sets with 1000+ entries