### PR TITLE
Allow pushing non-rescanned files with covers

### DIFF
--- a/src-tauri/src/commands/scan.rs
+++ b/src-tauri/src/commands/scan.rs
@@ -37,19 +37,20 @@ pub async fn import_folders(paths: Vec<String>) -> Result<scanner::ScanResult, S
 }
 
 #[tauri::command]
-pub async fn scan_library(paths: Vec<String>) -> Result<scanner::ScanResult, String> {
-    println!("🔍 scan_library called with {} paths", paths.len());
-    
+pub async fn scan_library(paths: Vec<String>, force: Option<bool>) -> Result<scanner::ScanResult, String> {
+    let force = force.unwrap_or(false);
+    println!("🔍 scan_library called with {} paths (force={})", paths.len(), force);
+
     CANCEL_FLAG.store(false, Ordering::SeqCst);
-    
+
     // FORCE cache clear every time to prevent stale data issues
     if let Err(e) = crate::cache::clear() {
         println!("⚠️ Cache clear failed: {}", e);
     } else {
         println!("🗑️ Cache cleared successfully");
     }
-    
-    let result = scanner::scan_directories(&paths, Some(CANCEL_FLAG.clone()))
+
+    let result = scanner::scan_directories(&paths, Some(CANCEL_FLAG.clone()), force)
         .await
         .map_err(|e| {
             println!("❌ Scan error: {}", e);

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -133,9 +133,10 @@ async fn fetch_covers_for_groups(
 
 pub async fn scan_directories(
     paths: &[String],
-    cancel_flag: Option<Arc<AtomicBool>>
+    cancel_flag: Option<Arc<AtomicBool>>,
+    force: bool
 ) -> Result<ScanResult, Box<dyn std::error::Error + Send + Sync>> {
-    println!("🔍 Starting scan of {} paths", paths.len());
+    println!("🔍 Starting scan of {} paths (force={})", paths.len(), force);
 
     // ✅ THIS LINE MUST BE HERE
     crate::progress::reset_progress();
@@ -174,7 +175,8 @@ pub async fn scan_directories(
     let processed_groups = processor::process_all_groups(
         groups,
         &config,
-        cancel_flag.clone()
+        cancel_flag.clone(),
+        force
     ).await?;
 
     Ok(ScanResult {

--- a/src/hooks/useScan.js
+++ b/src/hooks/useScan.js
@@ -300,7 +300,8 @@ export function useScan() {
         let allNewGroups = [];
         for (const path of paths) {
           try {
-            const result = await invoke('scan_library', { paths: [path] });
+            // Pass force: true to rescan even if metadata.json exists
+            const result = await invoke('scan_library', { paths: [path], force: true });
             if (result && result.groups) {
               allNewGroups.push(...result.groups);
             }


### PR DESCRIPTION
When using the rescan button, now pass force=true to the scan_library command which bypasses the optimization that skips API calls for books with existing metadata.json files. This allows users to re-fetch fresh metadata from Audible/Google Books for books they've already imported.