### PR TITLE
feat: Add collection detection, fix author ordering, add rescan options

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,4 +35,5 @@ mp4ameta = "0.11"
 uuid = { version = "1.18.1", features = ["v4"] }
 csv = "1.3"
 base64 = "0.22"
+indexmap = "2"
 

--- a/src-tauri/src/scanner/collector.rs
+++ b/src-tauri/src/scanner/collector.rs
@@ -117,6 +117,9 @@ fn load_metadata_json(folder_path: &str) -> (Option<BookMetadata>, bool) {
         explicit: None,
         publish_date: None,
         sources: None,
+        // Collection fields - detected later in processing
+        is_collection: false,
+        collection_books: vec![],
     }), true)
 }
 
@@ -281,6 +284,9 @@ fn group_files_by_book(files: Vec<RawFileData>) -> Vec<BookGroup> {
                     explicit: None,
                     publish_date: None,
                     sources: None,
+                    // Collection fields - detected later in processing
+                    is_collection: false,
+                    collection_books: vec![],
                 }, ScanStatus::NotScanned)
             };
 

--- a/src-tauri/src/scanner/types.rs
+++ b/src-tauri/src/scanner/types.rs
@@ -109,6 +109,21 @@ pub enum ScanStatus {
     NotScanned,
 }
 
+/// Scan mode options for different rescan behaviors
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanMode {
+    /// Default: Skip if metadata.json exists
+    #[default]
+    Normal,
+    /// Bypass metadata.json but use cached API results (quick refresh)
+    RefreshMetadata,
+    /// Clear all caches AND bypass metadata.json (full fresh scan)
+    ForceFresh,
+    /// Re-fetch only specified fields (selective refresh)
+    SelectiveRefresh,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BookMetadata {
     #[serde(default)]
@@ -166,6 +181,14 @@ pub struct BookMetadata {
     /// Source tracking - where each metadata field came from
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sources: Option<MetadataSources>,
+
+    // COLLECTION DETECTION FIELDS
+    /// Whether this audiobook is a collection/omnibus containing multiple books
+    #[serde(default)]
+    pub is_collection: bool,
+    /// List of individual book titles if this is a collection
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub collection_books: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/scanner/ActionBar.jsx
+++ b/src/components/scanner/ActionBar.jsx
@@ -1,4 +1,11 @@
-import { CheckCircle, RefreshCw, Save, FileType, UploadCloud, Edit3 } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import { CheckCircle, RefreshCw, Save, FileType, UploadCloud, Edit3, ChevronDown } from 'lucide-react';
+
+// Scan mode options for rescan dropdown
+const SCAN_MODES = [
+  { id: 'refresh_metadata', label: 'Quick Refresh', description: 'Use cached API data, bypass local metadata' },
+  { id: 'force_fresh', label: 'Full Rescan', description: 'Clear caches and fetch fresh data' },
+];
 
 export function ActionBar({
   selectedFiles,
@@ -16,6 +23,24 @@ export function ActionBar({
   pushing,
   scanning
 }) {
+  const [showRescanMenu, setShowRescanMenu] = useState(false);
+  const rescanMenuRef = useRef(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (rescanMenuRef.current && !rescanMenuRef.current.contains(event.target)) {
+        setShowRescanMenu(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleRescanWithMode = (mode) => {
+    setShowRescanMenu(false);
+    onRescan(mode);
+  };
   // Calculate total file count (for allSelected mode)
   const totalFileCount = groups.reduce((sum, g) => sum + g.files.length, 0);
   const selectedCount = allSelected ? totalFileCount : selectedFiles.size;
@@ -96,14 +121,44 @@ export function ActionBar({
             </div>
 
             <div className="flex items-center gap-3">
-              <button
-                onClick={onRescan}
-                disabled={scanning}
-                className="px-4 py-2 bg-white border border-blue-300 text-blue-700 rounded-lg hover:bg-blue-50 transition-colors font-medium flex items-center gap-2"
-              >
-                <RefreshCw className={`w-4 h-4 ${scanning ? 'animate-spin' : ''}`} />
-                {scanning ? 'Rescanning...' : `Rescan ${selectedCount === 1 ? 'File' : `${selectedCount} Files`}`}
-              </button>
+              {/* Rescan Split Button with Dropdown */}
+              <div className="relative" ref={rescanMenuRef}>
+                <div className="flex">
+                  <button
+                    onClick={() => handleRescanWithMode('force_fresh')}
+                    disabled={scanning}
+                    className="px-4 py-2 bg-white border border-blue-300 border-r-0 text-blue-700 rounded-l-lg hover:bg-blue-50 transition-colors font-medium flex items-center gap-2"
+                  >
+                    <RefreshCw className={`w-4 h-4 ${scanning ? 'animate-spin' : ''}`} />
+                    {scanning ? 'Rescanning...' : `Rescan ${selectedCount === 1 ? 'File' : `${selectedCount} Files`}`}
+                  </button>
+                  <button
+                    onClick={() => setShowRescanMenu(!showRescanMenu)}
+                    disabled={scanning}
+                    className="px-2 py-2 bg-white border border-blue-300 text-blue-700 rounded-r-lg hover:bg-blue-50 transition-colors"
+                  >
+                    <ChevronDown className="w-4 h-4" />
+                  </button>
+                </div>
+
+                {/* Dropdown Menu */}
+                {showRescanMenu && (
+                  <div className="absolute right-0 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+                    <div className="py-1">
+                      {SCAN_MODES.map(mode => (
+                        <button
+                          key={mode.id}
+                          onClick={() => handleRescanWithMode(mode.id)}
+                          className="w-full px-4 py-2 text-left hover:bg-gray-50 transition-colors"
+                        >
+                          <div className="font-medium text-gray-900">{mode.label}</div>
+                          <div className="text-xs text-gray-500">{mode.description}</div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
 
               {filesWithChanges.length > 0 && (
                 <button

--- a/src/pages/ScannerPage.jsx
+++ b/src/pages/ScannerPage.jsx
@@ -419,15 +419,17 @@ export function ScannerPage({ onActionsReady }) {
     setShowRenameModal(true);
   };
 
-  // ✅ SIMPLIFIED - No popup, just rescan
-  const handleRescanClick = async () => {
+  // ✅ Rescan with configurable mode
+  // @param {string} scanMode - 'refresh_metadata' or 'force_fresh'
+  const handleRescanClick = async (scanMode = 'force_fresh') => {
     const selectedCount = getSelectedCount(groups);
     if (selectedCount === 0 && !allSelected) return;
 
     try {
-      console.log(`🔄 Rescanning ${selectedCount} files...`);
+      const modeLabel = scanMode === 'refresh_metadata' ? 'quick refresh' : 'full rescan';
+      console.log(`🔄 ${modeLabel} for ${selectedCount} files...`);
       const actualSelectedFiles = getSelectedFileIds(groups);
-      const result = await handleRescan(actualSelectedFiles, groups);
+      const result = await handleRescan(actualSelectedFiles, groups, scanMode);
       console.log(`✅ Rescanned ${result.count} books`);
       handleClearSelection();
       clearFileStatuses();


### PR DESCRIPTION
- Fix author/narrator extraction ordering by using IndexSet instead of HashSet to preserve the order of authors and narrators as they appear on Audible

- Add synchronization between author/authors[0] and narrator/narrators[0] to ensure consistency after GPT processing

- Add collection detection for audiobooks containing multiple books:
  - Detect collection keywords (collection, omnibus, box set, etc.)
  - Detect "Books X-Y" patterns in titles
  - Flag very long runtimes (>50 hours) as potential collections
  - Extract individual book titles from descriptions
  - New metadata fields: is_collection, collection_books

- Add ScanMode enum with multiple rescan options:
  - Normal: Skip if metadata.json exists (default)
  - RefreshMetadata: Bypass metadata.json but use cached API results
  - ForceFresh: Clear all caches and fetch fresh data
  - SelectiveRefresh: Refresh specific fields only

- Update frontend with rescan options dropdown:
  - Quick Refresh: Uses cached API data
  - Full Rescan: Clears caches for fresh data