### PR TITLE
fix: Improve clear_all_genres to work without full ABS rescan

### DIFF
--- a/src-tauri/src/commands/maintenance.rs
+++ b/src-tauri/src/commands/maintenance.rs
@@ -72,71 +72,166 @@ pub async fn clear_all_genres() -> Result<String, String> {
 
     let filter_data: LibraryFilterData = filter_response.json().await.map_err(|e| e.to_string())?;
     let all_dropdown_genres: HashSet<String> = filter_data.genres.into_iter().collect();
+    let initial_genre_count = all_dropdown_genres.len();
 
-    // Fetch all library items to find which genres are actually in use
-    let items_url = format!("{}/api/libraries/{}/items?limit=1000", config.abs_base_url, config.abs_library_id);
-    let items_response = client
-        .get(&items_url)
-        .header("Authorization", format!("Bearer {}", config.abs_api_token))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let items: LibraryItemsResponse = items_response.json().await.map_err(|e| e.to_string())?;
-
-    // Collect all genres that are actually assigned to books
+    // Fetch ALL library items with pagination to find which genres are actually in use
     let mut used_genres: HashSet<String> = HashSet::new();
-    for item in items.results {
-        if let Some(genres) = item.media.metadata.genres {
-            used_genres.extend(genres);
+    let mut page = 0;
+    let limit = 500;
+
+    loop {
+        let items_url = format!(
+            "{}/api/libraries/{}/items?limit={}&page={}",
+            config.abs_base_url, config.abs_library_id, limit, page
+        );
+
+        let items_response = client
+            .get(&items_url)
+            .header("Authorization", format!("Bearer {}", config.abs_api_token))
+            .send()
+            .await
+            .map_err(|e| format!("Failed to fetch items page {}: {}", page, e))?;
+
+        if !items_response.status().is_success() {
+            return Err(format!("Failed to fetch items: {}", items_response.status()));
+        }
+
+        let items: LibraryItemsResponse = items_response.json().await.map_err(|e| e.to_string())?;
+        let batch_size = items.results.len();
+
+        // Collect genres from this batch
+        for item in items.results {
+            if let Some(genres) = item.media.metadata.genres {
+                used_genres.extend(genres);
+            }
+        }
+
+        // Check if we've fetched all items
+        if batch_size < limit {
+            break;
+        }
+        page += 1;
+
+        // Safety limit to prevent infinite loops
+        if page > 100 {
+            println!("⚠️ Reached page limit, library may have >50,000 items");
+            break;
         }
     }
 
     // Find unused genres (in dropdown but not assigned to any book)
     let unused_genres: Vec<String> = all_dropdown_genres
-        .into_iter()
-        .filter(|g| !used_genres.contains(g))
+        .iter()
+        .filter(|g| !used_genres.contains(*g))
+        .cloned()
         .collect();
 
     if unused_genres.is_empty() {
-        return Ok("No unused genres found - all genres are assigned to at least one book".to_string());
+        return Ok(format!(
+            "No unused genres found - all {} genres are assigned to at least one book",
+            initial_genre_count
+        ));
     }
 
-    // Try to remove unused genres by purging the library cache
+    println!("📋 Found {} unused genres: {:?}", unused_genres.len(), unused_genres);
+
+    // Step 1: Purge the library cache to clear stale filterdata
     let cache_url = format!("{}/api/libraries/{}/purge-cache", config.abs_base_url, config.abs_library_id);
-    let cache_response = client
+    let cache_result = client
         .post(&cache_url)
         .header("Authorization", format!("Bearer {}", config.abs_api_token))
         .send()
         .await;
 
-    let removed = match cache_response {
-        Ok(resp) if resp.status().is_success() => true,
-        _ => false,
+    match &cache_result {
+        Ok(resp) if resp.status().is_success() => {
+            println!("✅ Library cache purged successfully");
+        }
+        Ok(resp) => {
+            println!("⚠️ Cache purge returned status: {}", resp.status());
+        }
+        Err(e) => {
+            println!("⚠️ Cache purge failed: {}", e);
+        }
+    }
+
+    // Step 2: Wait briefly for cache to clear
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Step 3: Force filterdata rebuild by making a fresh request
+    let rebuild_response = client
+        .get(&filter_url)
+        .header("Authorization", format!("Bearer {}", config.abs_api_token))
+        .send()
+        .await;
+
+    // Step 4: Verify the genres were removed
+    let final_genre_count = match rebuild_response {
+        Ok(resp) if resp.status().is_success() => {
+            match resp.json::<LibraryFilterData>().await {
+                Ok(data) => {
+                    let remaining_unused: Vec<&String> = unused_genres
+                        .iter()
+                        .filter(|g| data.genres.contains(g))
+                        .collect();
+
+                    if remaining_unused.is_empty() {
+                        println!("✅ All {} unused genres successfully removed", unused_genres.len());
+                        Some((data.genres.len(), true))
+                    } else {
+                        println!("⚠️ {} genres still remain in dropdown", remaining_unused.len());
+                        Some((data.genres.len(), false))
+                    }
+                }
+                Err(_) => None,
+            }
+        }
+        _ => None,
     };
 
-    if removed {
-        Ok(format!("Removed {} unused genres: {}", unused_genres.len(), unused_genres.join(", ")))
-    } else {
-        // Fallback: try to trigger a quick metadata refresh via library settings
-        let settings_url = format!("{}/api/libraries/{}/settings", config.abs_base_url, config.abs_library_id);
-        let settings_response = client
-            .patch(&settings_url)
-            .header("Authorization", format!("Bearer {}", config.abs_api_token))
-            .json(&json!({}))
-            .send()
-            .await;
+    match final_genre_count {
+        Some((new_count, true)) => {
+            Ok(format!(
+                "Successfully cleared {} unused genres! ({} → {} genres in dropdown)",
+                unused_genres.len(),
+                initial_genre_count,
+                new_count
+            ))
+        }
+        Some((new_count, false)) => {
+            // Genres still present - try triggering a library metadata refresh
+            let scan_url = format!("{}/api/libraries/{}/scan", config.abs_base_url, config.abs_library_id);
+            let scan_result = client
+                .post(&scan_url)
+                .header("Authorization", format!("Bearer {}", config.abs_api_token))
+                .json(&json!({"force": false}))
+                .send()
+                .await;
 
-        match settings_response {
-            Ok(resp) if resp.status().is_success() => {
-                Ok(format!("Removed {} unused genres: {}", unused_genres.len(), unused_genres.join(", ")))
+            match scan_result {
+                Ok(resp) if resp.status().is_success() => {
+                    Ok(format!(
+                        "Found {} unused genres. Triggered quick library refresh to remove them. Check ABS in a few seconds. ({} → {} genres currently)",
+                        unused_genres.len(),
+                        initial_genre_count,
+                        new_count
+                    ))
+                }
+                _ => {
+                    Ok(format!(
+                        "Found {} unused genres: {}. Cache was purged but ABS may need a quick refresh. Go to ABS Settings > Libraries and click the refresh icon.",
+                        unused_genres.len(),
+                        unused_genres.join(", ")
+                    ))
+                }
             }
-            _ => {
-                Ok(format!("Found {} unused genres but could not remove them automatically: {}. Try restarting AudiobookShelf to clear cached data.",
-                    unused_genres.len(),
-                    unused_genres.join(", ")
-                ))
-            }
+        }
+        None => {
+            Ok(format!(
+                "Purged cache for {} unused genres: {}. Refresh the ABS page to see updated genre list.",
+                unused_genres.len(),
+                unused_genres.join(", ")
+            ))
         }
     }
 }


### PR DESCRIPTION
- Add pagination to fetch all library items (not just first 1000)
- Purge library cache and force filterdata rebuild
- Verify if unused genres were actually removed
- Fallback to quick (non-force) library scan if cache purge insufficient
- Provide better feedback messages with before/after genre counts