### PR TITLE
Refactor scan to support clean rescans faster

### DIFF
--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -124,7 +124,7 @@ async fn fetch_covers_for_groups(
                 group
             }
         })
-        .buffer_unordered(10)  // Fetch 10 covers concurrently
+        .buffer_unordered(30)  // Fetch 30 covers concurrently for faster imports
         .collect()
         .await;
 

--- a/src-tauri/src/scanner/processor.rs
+++ b/src-tauri/src/scanner/processor.rs
@@ -182,7 +182,7 @@ pub async fn process_all_groups(
                 result
             }
         })
-        .buffer_unordered(20)  // Increased concurrency for better throughput
+        .buffer_unordered(50)  // High concurrency for maximum throughput
         .filter_map(|r| async { r.ok() })
         .collect()
         .await;

--- a/src/components/scanner/ActionBar.jsx
+++ b/src/components/scanner/ActionBar.jsx
@@ -1,11 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
-import { CheckCircle, RefreshCw, Save, FileType, UploadCloud, Edit3, ChevronDown } from 'lucide-react';
-
-// Scan mode options for rescan dropdown
-const SCAN_MODES = [
-  { id: 'refresh_metadata', label: 'Quick Refresh', description: 'Use cached API data, bypass local metadata' },
-  { id: 'force_fresh', label: 'Full Rescan', description: 'Clear caches and fetch fresh data' },
-];
+import { CheckCircle, RefreshCw, Save, FileType, UploadCloud, Edit3 } from 'lucide-react';
 
 export function ActionBar({
   selectedFiles,
@@ -23,24 +16,6 @@ export function ActionBar({
   pushing,
   scanning
 }) {
-  const [showRescanMenu, setShowRescanMenu] = useState(false);
-  const rescanMenuRef = useRef(null);
-
-  // Close menu when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event) {
-      if (rescanMenuRef.current && !rescanMenuRef.current.contains(event.target)) {
-        setShowRescanMenu(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleRescanWithMode = (mode) => {
-    setShowRescanMenu(false);
-    onRescan(mode);
-  };
   // Calculate total file count (for allSelected mode)
   const totalFileCount = groups.reduce((sum, g) => sum + g.files.length, 0);
   const selectedCount = allSelected ? totalFileCount : selectedFiles.size;
@@ -121,44 +96,15 @@ export function ActionBar({
             </div>
 
             <div className="flex items-center gap-3">
-              {/* Rescan Split Button with Dropdown */}
-              <div className="relative" ref={rescanMenuRef}>
-                <div className="flex">
-                  <button
-                    onClick={() => handleRescanWithMode('force_fresh')}
-                    disabled={scanning}
-                    className="px-4 py-2 bg-white border border-blue-300 border-r-0 text-blue-700 rounded-l-lg hover:bg-blue-50 transition-colors font-medium flex items-center gap-2"
-                  >
-                    <RefreshCw className={`w-4 h-4 ${scanning ? 'animate-spin' : ''}`} />
-                    {scanning ? 'Rescanning...' : `Rescan ${selectedCount === 1 ? 'File' : `${selectedCount} Files`}`}
-                  </button>
-                  <button
-                    onClick={() => setShowRescanMenu(!showRescanMenu)}
-                    disabled={scanning}
-                    className="px-2 py-2 bg-white border border-blue-300 text-blue-700 rounded-r-lg hover:bg-blue-50 transition-colors"
-                  >
-                    <ChevronDown className="w-4 h-4" />
-                  </button>
-                </div>
-
-                {/* Dropdown Menu */}
-                {showRescanMenu && (
-                  <div className="absolute right-0 mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
-                    <div className="py-1">
-                      {SCAN_MODES.map(mode => (
-                        <button
-                          key={mode.id}
-                          onClick={() => handleRescanWithMode(mode.id)}
-                          className="w-full px-4 py-2 text-left hover:bg-gray-50 transition-colors"
-                        >
-                          <div className="font-medium text-gray-900">{mode.label}</div>
-                          <div className="text-xs text-gray-500">{mode.description}</div>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
+              {/* Simple Rescan Button */}
+              <button
+                onClick={() => onRescan('force_fresh')}
+                disabled={scanning}
+                className="px-4 py-2 bg-white border border-blue-300 text-blue-700 rounded-lg hover:bg-blue-50 transition-colors font-medium flex items-center gap-2"
+              >
+                <RefreshCw className={`w-4 h-4 ${scanning ? 'animate-spin' : ''}`} />
+                {scanning ? 'Rescanning...' : `Rescan ${selectedCount === 1 ? 'File' : `${selectedCount} Files`}`}
+              </button>
 
               {filesWithChanges.length > 0 && (
                 <button

--- a/src/components/scanner/BookList.jsx
+++ b/src/components/scanner/BookList.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X, Download, FolderPlus, Sparkles, FileJson } from 'lucide-react';
+import { Upload, CheckCircle, FileAudio, ChevronRight, ChevronDown, Book, Search, Filter, X, Download, FolderPlus, Sparkles, FileJson, Zap } from 'lucide-react';
 
 // Virtualized item height (approximate)
 const ITEM_HEIGHT = 140;
@@ -218,32 +218,47 @@ export function BookList({
   if (groups.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center p-8 bg-white">
-        <div className="text-center max-w-sm">
+        <div className="text-center max-w-md">
           <div className="bg-gradient-to-br from-blue-50 to-indigo-100 rounded-2xl p-8 border border-blue-200">
             <Upload className="w-12 h-12 text-blue-400 mx-auto mb-4" />
             <h3 className="text-lg font-semibold text-gray-900 mb-2">No Files Scanned</h3>
             <p className="text-gray-600 mb-6 text-sm">Select a folder to scan for audiobook files and view metadata</p>
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-3">
+              {/* Smart Scan - default */}
               <button
-                onClick={onScan}
+                onClick={() => onScan('normal')}
                 disabled={scanning}
-                className="w-full px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium disabled:opacity-50"
+                className="w-full px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium disabled:opacity-50 flex items-center justify-center gap-2"
               >
-                {scanning ? 'Scanning...' : 'Scan Library'}
+                <Zap className="w-4 h-4" />
+                {scanning ? 'Scanning...' : 'Smart Scan'}
               </button>
+
+              {/* Clean Scan - secondary */}
+              <button
+                onClick={() => onScan('force_fresh')}
+                disabled={scanning}
+                className="w-full px-4 py-2.5 bg-white border border-blue-300 text-blue-700 rounded-lg hover:bg-blue-50 transition-colors font-medium disabled:opacity-50 flex items-center justify-center gap-2 text-sm"
+              >
+                <Sparkles className="w-4 h-4" />
+                Clean Scan (Clear Caches)
+              </button>
+
               {onImport && (
                 <button
                   onClick={onImport}
                   disabled={scanning}
-                  className="w-full px-4 py-2.5 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium disabled:opacity-50 text-sm"
+                  className="w-full px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium disabled:opacity-50 text-sm flex items-center justify-center gap-2"
                 >
+                  <FolderPlus className="w-4 h-4" />
                   Import Without Scanning
                 </button>
               )}
             </div>
-            <p className="text-xs text-gray-500 mt-3">
-              Import adds folders without fetching metadata from online sources
-            </p>
+            <div className="mt-4 text-xs text-gray-500 space-y-1">
+              <p><strong>Smart Scan:</strong> Skips books with existing metadata</p>
+              <p><strong>Clean Scan:</strong> Fetches fresh data for all books</p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Add scan mode dropdown to main "Scan Library" button in header
  - Smart Scan: Skip books with existing metadata (default)
  - Clean Scan: Clear caches and fetch all fresh data
- Move scan mode selection from rescan to initial scan
- Simplify rescan button (always does force_fresh, no dropdown)
- Update empty state with two scan buttons (Smart/Clean)
- Increase parallel processing concurrency:
  - Book processing: 20 -> 50 concurrent
  - Cover fetching: 10 -> 30 concurrent
  - Root path collection: parallelize across 10 paths