### PR TITLE
feat: Add author mismatch detection and fix maintenance functions

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -50,6 +50,8 @@ fn main() {
             commands::maintenance::normalize_genres,
             commands::maintenance::clear_all_genres,
             commands::maintenance::get_genre_stats,
+            commands::maintenance::get_author_stats,
+            commands::maintenance::fix_author_mismatches,
             commands::audible::login_to_audible,
             commands::audible::check_audible_installed,
             commands::covers::get_cover_for_group,


### PR DESCRIPTION
- Add get_author_stats() to detect author mismatches in ABS
  - Compares ABS metadata with embedded file tags
  - Reports count of books with mismatched authors
- Add fix_author_mismatches() to batch fix wrong authors
  - Reads author from file tags (album artist or artist)
  - Updates ABS if author doesn't match file tags
  - Special handling for famous authors (J.K. Rowling, etc.)
- Add Author Management section to Maintenance page
  - "Fix Author Mismatches" button with confirmation
  - "View Author Statistics" button
  - Stats shown in header alongside genre/cache stats

This allows fixing the 358 books wrongly assigned to J.K. Rowling (and similar issues) by restoring authors from file tags.