### PR TITLE
Improve scanner robustness and metadata priority

### DIFF
--- a/src-tauri/src/scanner/processor.rs
+++ b/src-tauri/src/scanner/processor.rs
@@ -652,6 +652,23 @@ fn looks_like_author_name(name: &str) -> bool {
         return false;
     }
 
+    // Contains brackets (often ASIN or year) - not an author name
+    if name.contains('[') || name.contains(']') || name.contains('(') || name.contains(')') {
+        return false;
+    }
+
+    // Contains comma - likely "Series Name, Book X" format
+    if name.contains(',') {
+        return false;
+    }
+
+    // Contains "Book" followed by a number or # - series info, not author
+    if let Ok(book_num_regex) = regex::Regex::new(r"(?i)book\s*[#]?\d") {
+        if book_num_regex.is_match(name) {
+            return false;
+        }
+    }
+
     // Common false positives - series names, descriptors, etc.
     let false_positives = [
         "the ", "a ", "an ", "book", "volume", "vol", "part", "chapter",
@@ -662,6 +679,17 @@ fn looks_like_author_name(name: &str) -> bool {
     let name_lower = name.to_lowercase();
     for fp in &false_positives {
         if name_lower.starts_with(fp) {
+            return false;
+        }
+    }
+
+    // Check for false positives ANYWHERE in the name (not just start)
+    let anywhere_false_positives = [
+        " series", " book ", " volume ", " trilogy", " saga",
+        " collection", "'s money", "'s guide", "'s handbook",
+    ];
+    for fp in &anywhere_false_positives {
+        if name_lower.contains(fp) {
             return false;
         }
     }


### PR DESCRIPTION
- Reject names containing brackets (ASINs, years like [B0036IOYQE] or (1998))
- Reject names containing commas (series info like "Series, Book 2")
- Reject names containing "Book" followed by number ("Book #2", "Book 1")
- Reject patterns like "'s Money", "'s Guide" (company/brand names)
- Check for series/book/volume keywords anywhere in name, not just start

This fixes false positives like:
- "Kiplinger's Money" → rejected (contains "'s money")
- "Earthseed Series, Book 2" → rejected (contains comma, series, book)
- "Left Behind [1234]" → rejected (contains brackets)