### PR TITLE
Fix broken book data and display logic

### DIFF
--- a/src-tauri/src/scanner/collector.rs
+++ b/src-tauri/src/scanner/collector.rs
@@ -80,11 +80,9 @@ fn load_metadata_json(folder_path: &str) -> (Option<BookMetadata>, bool) {
     });
 
     let author = abs_meta.authors.first().cloned().unwrap_or_else(|| "Unknown".to_string());
-    let narrator = if abs_meta.narrators.is_empty() {
-        None
-    } else {
-        Some(abs_meta.narrators.join(", "))
-    };
+    // CRITICAL FIX: Keep narrator as single value (first narrator), not joined string
+    // The narrators array is stored separately and used for metadata.json
+    let narrator = abs_meta.narrators.first().cloned();
 
     let (series, sequence) = if let Some(first_series) = abs_meta.series.first() {
         (Some(first_series.name.clone()), first_series.sequence.clone())


### PR DESCRIPTION
…tors, and covers

This commit addresses critical bugs in the metadata processing pipeline that caused:
- Empty titles when writing metadata.json
- Missing or incorrect authors
- Narrators being lost or mangled
- Cover art not being saved to book folders

Root cause: calculate_changes() only recorded fields that changed, but build_metadata_from_changes() used empty defaults for missing fields. This meant if a file already had correct metadata, the written metadata.json would have empty values.

Changes:

1. processor.rs - calculate_changes():
   - Now ALWAYS includes title, author, album fields
   - Added authors_json, narrators_json, genres_json fields with serialized arrays
   - Added subtitle field support
   - Added cover_url field for cover saving

2. commands/tags.rs - build_metadata_from_changes():
   - Uses new JSON array fields for proper authors/narrators/genres handling
   - Added fallback logic for backwards compatibility
   - Filters out empty values with .filter()

3. commands/tags.rs - save_cover_to_folder():
   - New function to download and save cover art as cover.jpg/cover.png
   - Integrated into write_tags workflow

4. collector.rs - load_metadata_json():
   - Fixed narrator loading: now keeps first narrator as single value
   - Preserves narrators array separately for metadata.json writing